### PR TITLE
Add detail to Malformed XML Dict builder exception

### DIFF
--- a/src/org/albite/dictionary/builder/DictBuilder.java
+++ b/src/org/albite/dictionary/builder/DictBuilder.java
@@ -126,7 +126,8 @@ public class DictBuilder {
                     doc = null;
                     throw new DictBuilderException(
                             "Malformed XML document. You need to have all &"
-                            + "as &amp; for the parser to work.");
+                            + "as &amp; for the parser to work."
+                            + "\nDetail: "+xppe.getLocalizedMessage());
                 }
 
                 System.out.println(


### PR DESCRIPTION
Add detail to Malformed XML Dict builder exception, it's usefull because has problem's line number
